### PR TITLE
Add serial package as a build dependency

### DIFF
--- a/mirobot_urdf_2/package.xml
+++ b/mirobot_urdf_2/package.xml
@@ -15,6 +15,7 @@ for mirobot_urdf_2 robot</p>
   <depend>rviz</depend>
   <depend>joint_state_publisher</depend>
   <depend>gazebo</depend>
+  <depend>serial</depend>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>


### PR DESCRIPTION
This dependency needs to be listed so that the topological order can be properly constructed when building.